### PR TITLE
layouts: head: update data-domain for umami

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,11 +18,12 @@
   <script src="{{ $mainJs.RelPermalink }}" type="text/javascript"></script>
   <!-- toc.js -->
   {{ $tocJs := resources.Get "js/toc.js" | js.Build "toc.js" | minify | fingerprint }}
+  <!-- umami.js -->
   <script src="{{ $tocJs.RelPermalink }}" type="text/javascript"></script>
   <script 
   async 
   defer 
-  data-domains="silviacanelon.com"
+  data-domains="www.silviacanelon.com"
   data-website-id="959d1d62-7a8b-41cd-92ca-be0884ebdf46" 
   src="https://silvia.up.railway.app/umami.js"></script>
 </head>


### PR DESCRIPTION
Update data-domain in umami script.

Reason: It didn't seem to be tracking properly, possibly because of permanent redirects from `silviacanelon.com`