### PR TITLE
redirects: reorder rules to catch old posts

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -3,13 +3,14 @@
 # https://explorers.netlify.com/learn/exploring-netlify-redirects/getting-started-configuring-redirects
 
 https://silvia.rbind.io/authors/silvia/avatar.png   https://www.silviacanelon.com/about/sidebar/avatar.png 301!
-http://silvia.rbind.io/*                            https://www.silviacanelon.com/:splat 301!
-https://silvia.rbind.io/*                           https://www.silviacanelon.com/:splat 301!
 
 https://silvia.rbind.io/post/*                      https://www.silviacanelon.com/blog/:splat 301!
 https://silvia.rbind.io/blog/*                      https://www.silviacanelon.com/blog/:splat 301!
 https://silvia.rbind.io/talk/*                      https://www.silviacanelon.com/talk/:splat 301!
 https://silvia.rbind.io/project/*                   https://www.silviacanelon.com/project/:splat 301!
+
+http://silvia.rbind.io/*                            https://www.silviacanelon.com/:splat 301!
+https://silvia.rbind.io/*                           https://www.silviacanelon.com/:splat 301!
 
 http://silviacanelon.com/*                          https://www.silviacanelon.com/:splat 301!
 https://silviacanelon.com/*                         https://www.silviacanelon.com/:splat 301!


### PR DESCRIPTION
Noticed old post links were not redirecting appropriately. Trying to reorder rules to see if they get caught.

I.e. [silvia.rbind.io/blog/hello-hugo-apero](https://silvia.rbind.io/blog/hello-hugo-apero) should redirect to [silviacanelon.com/blog/2021-hello-hugo-apero](https://www.silviacanelon.com/blog/2021-hello-hugo-apero)